### PR TITLE
Add Clangd Key Map for only C/C++ files

### DIFF
--- a/KaiLib_neovim/lua/config/keymaps.lua
+++ b/KaiLib_neovim/lua/config/keymaps.lua
@@ -39,3 +39,16 @@ km.set("n", "<leader>gs", ":Git<CR>" , { noremap = true, silent = true, desc = "
 
 -- Keymaps for maximize.nvim
 km.set("n", "<leader>m", ":Maximize<CR>", { noremap = true, silent = true, desc = "Maximize current window" })
+--
+-- Keymaps for .c/.cpp/.h/.hpp files
+vim.api.nvim_create_autocmd("FileType", {
+    pattern = { "c", "cpp", "objc", "objcpp", "h", "hpp" },
+    callback = function(args)
+        vim.api.nvim_buf_set_keymap(args.buf, "n", "gR", "<cmd>ClangdRename<CR>", {noremap = true, silent = true})
+        vim.api.nvim_buf_set_keymap(args.buf, "n", "gA", "<cmd>ClangdCodeAction<CR>", { noremap = true, silent = true })
+        vim.api.nvim_buf_set_keymap(args.buf, "n", "gF", "<cmd>ClangdFormat<CR>", { noremap = true, silent = true })
+        vim.api.nvim_buf_set_keymap(args.buf, "n", "gI", "<cmd>ClangdImplementations<CR>", { noremap = true, silent = true })
+        vim.api.nvim_buf_set_keymap(args.buf, "n", "gD", "<cmd>ClangdTypeHierarchy<CR>", { noremap = true, silent = true })
+        vim.api.nvim_buf_set_keymap(args.buf, "n", "gH", "<cmd>ClangdSwitchSourceHeader<CR>", { noremap = true, silent = true })
+    end,
+})

--- a/KaiLib_neovim/lua/config/lsp.lua
+++ b/KaiLib_neovim/lua/config/lsp.lua
@@ -9,7 +9,6 @@ local on_attach = function(client, bufnr)
     vim.keymap.set("n", "gk", vim.lsp.buf.hover, opts)
     vim.keymap.set("n", "gsh", vim.lsp.buf.signature_help, opts)
     vim.keymap.set("n", "gs", vim.lsp.buf.workspace_symbol, opts)
-    vim.keymap.set("n", "gh", "<cmd>ClangdSwitchSourceHeader<CR>", opts)
 
     if client.server_capabilities.documentSymbolProvider then
         require("nvim-navic").attach(client, bufnr)


### PR DESCRIPTION
Clangd key map are created outside LSP settings, since there is file type identification problem if we do it inside LSP configs.